### PR TITLE
[iOS] Use install_modules_dependencies in .podspec file

### DIFF
--- a/react-native-pager-view.podspec
+++ b/react-native-pager-view.podspec
@@ -16,21 +16,27 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{h,m,mm}"
 
-  s.dependency "React-Core"
+  # install_modules_dependencies has been defined in RN 0.70
+  # This check ensure that the library can work on older versions of RN
+  if defined?(install_modules_dependencies)
+    install_modules_dependencies(s)
+  else
+    s.dependency "React-Core"
 
-  # Don't install the dependencies when we run `pod install` in the old architecture.
-  if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
-    s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
-    s.pod_target_xcconfig    = {
+    # Don't install the dependencies when we run `pod install` in the old architecture.
+    if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
+      s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
+      s.pod_target_xcconfig    = {
         "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
         "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
         "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
-    }
-    s.dependency "React-Codegen"
-    s.dependency "RCT-Folly"
-    s.dependency "RCTRequired"
-    s.dependency "RCTTypeSafety"
-    s.dependency "ReactCommon/turbomodule/core"
-    s.dependency "React-RCTFabric"
+      }
+      s.dependency "React-Codegen"
+      s.dependency "RCT-Folly"
+      s.dependency "RCTRequired"
+      s.dependency "RCTTypeSafety"
+      s.dependency "ReactCommon/turbomodule/core"
+      s.dependency "React-RCTFabric"
+    end
   end
 end


### PR DESCRIPTION
# Summary

In RN 0.70, the core team introduced the `install_modules_dependencies` function to properly configure the iOS dependencies in the podspec.
This allow the Core team to add/remove flags and restructure the internal Cocoapods' structure of React Native and limiting the chances to break 3rd parties dependencies, as those changes will be captured by the function.

By not using this function, all the 3rd party libraries would have to chase and manually reimplement the same changes that the RN Core team applies to the Cocoapods structure. 

## Test Plan

```
npx react-native@next init NewApp --version next --skip-install
cd NewApp
yarn add react-native-pager-view
yarn install
cd ios
bundle install
RCT_NEW_ARCH_ENABLED=1 bundle exec pod install
open NewApp.xcworkspace
```

Build and observe the failure.

<img width="752" alt="Screenshot 2023-11-30 at 09 58 10" src="https://github.com/cipolleschi/react-native-pager-view/assets/11162307/723b6765-cac6-4647-939a-73133dcc3945">

Apply this patch to the `NewApp/node_modules/react-native-pager-view/react-native-pager-view.podspec` file and rerun

```
RCT_NEW_ARCH_ENABLED=1 bundle exec pod install
open NewApp.xcworkspace
```
Build and observe the app build successfully:

<img width="752" alt="Screenshot 2023-11-30 at 10 03 31" src="https://github.com/cipolleschi/react-native-pager-view/assets/11162307/43e5d9a5-92c6-41ef-bd87-bfb6ecb88a0b">

### What's required for testing (prerequisites)?
Nothing

### What are the steps to reproduce (after prerequisites)?
See test plan

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅       |
| Android |    N/A      |

## Checklist

The below items are not needed:
- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
